### PR TITLE
add requirements.txt based on pip3 freeze

### DIFF
--- a/interlecture/requirements.txt
+++ b/interlecture/requirements.txt
@@ -1,0 +1,15 @@
+appdirs==1.4.0
+asgiref==1.0.0
+autobahn==0.17.1
+channels==1.0.3
+constantly==15.1.0
+daphne==1.0.2
+Django==1.10.5
+django-webpack-loader==0.4.1
+incremental==16.10.1
+packaging==16.8
+pyparsing==2.1.10
+six==1.10.0
+Twisted==16.6.0
+txaio==2.6.0
+zope.interface==4.3.3


### PR DESCRIPTION
Just so one can install the needed packages using pip3 install -r requirements.txt